### PR TITLE
epdc v2: improve behavior at high temperatures

### DIFF
--- a/drivers/video/fbdev/mxc/mxc_epdc_v2_fb.c
+++ b/drivers/video/fbdev/mxc/mxc_epdc_v2_fb.c
@@ -2833,7 +2833,15 @@ static int mxc_epdc_fb_get_temp_index(struct mxc_epdc_fb_data *fb_data, int temp
 
 	if (index < 0) {
 		dev_err(fb_data->dev,
-			"No TRT index match...using default temp index\n");
+			"No TRT index match (%d)\n", temp);
+		if (temp < fb_data->temp_range_bounds[0]) {
+			dev_dbg(fb_data->dev, "temperature < minimum range\n");
+			return 0;
+		}
+		if (temp >= fb_data->temp_range_bounds[fb_data->trt_entries-1]) {
+			dev_dbg(fb_data->dev, "temperature >= maximum range\n");
+			return (fb_data->trt_entries-1);
+		}
 		return DEFAULT_TEMP_INDEX;
 	}
 


### PR DESCRIPTION
Hi,

after reading in direct sunlight for half an hour today, screen refreshes suddenly became very slow, with heavy ghosting. It turns out that the temperature range table is only defined for temperatures ≤ 42 (as returned by tps6518x_get_temperature); at higher temperatures, the default index is used.

This patch is from the [Kobo kernel](https://github.com/kobolabs/Kobo-Reader) and instead uses the highest defined index for higher temperatures (and the lowest index for lower temperatures, but that is also the default, so the behavior is the same as before). I copied the code verbatim to make the file easier to diff with the downstream kernel.

Thanks!