### PR TITLE
tps6518x: set pdata before adding mfd devices

### DIFF
--- a/drivers/mfd/tps6518x.c
+++ b/drivers/mfd/tps6518x.c
@@ -478,11 +478,11 @@ static int tps6518x_probe(struct i2c_client *client)
 	if (ret)
 		return ret;
 
+	tps6518x->pdata = pdata;
+
 	devm_mfd_add_devices(tps6518x->dev, -1, tps6518x_devs,
 			ARRAY_SIZE(tps6518x_devs),
 			NULL, 0, NULL);
-
-	tps6518x->pdata = pdata;
 
 	dev_info(&client->dev, "PMIC TPS6518x for eInk display\n");
 


### PR DESCRIPTION
I've been packaging your work for Mobile NixOS:

https://mobile.nixos.org/

I'm using the 5.16 mainline kernel with your u-boot-fslc fork and I've got something booting and working. I struggled for a while with the MXC EPDC driver. It turns out the TPS6518x MFD driver was not setting the pdata before adding devices, it only set pdata afterwards. This meant the kernel would panic due to trying to dereference the NULL pdata when starting the TPS6518x regulator driver.

I'm not sure why this isn't reproduced under PostmarketOS. Maybe it's because Mobile NixOS doesn't yet support dynamic modules so the execution order is somehow different?

Let me know if this is a sensible change.